### PR TITLE
Computed fields and relations

### DIFF
--- a/src/Actions/ExportToExcel.php
+++ b/src/Actions/ExportToExcel.php
@@ -2,10 +2,10 @@
 
 namespace Maatwebsite\LaravelNovaExcel\Actions;
 
-use Laravel\Nova\Fields\Gravatar;
 use Laravel\Nova\Resource;
 use Laravel\Nova\Fields\Field;
 use Laravel\Nova\Actions\Action;
+use Laravel\Nova\Fields\Gravatar;
 use Illuminate\Support\Collection;
 use Maatwebsite\Excel\Facades\Excel;
 use Illuminate\Database\Query\Builder;
@@ -276,13 +276,10 @@ class ExportToExcel extends Action implements FromQuery, WithCustomChunkSize, Wi
             }
         }
 
-        $missingFields = array_diff($only, array_keys($row));
-
-        if (count($missingFields) > 0) {
-            foreach ($missingFields as $attribute) {
-                if ($model->{$attribute}) {
-                    $row[$attribute] = $model->{$attribute};
-                }
+        // Add fields that were requested by ->only(), but are not registered as fields in the Nova resource.
+        foreach (array_diff($only, array_keys($row)) as $attribute) {
+            if ($model->{$attribute}) {
+                $row[$attribute] = $model->{$attribute};
             }
         }
 

--- a/src/Actions/ExportToExcel.php
+++ b/src/Actions/ExportToExcel.php
@@ -281,7 +281,7 @@ class ExportToExcel extends Action implements FromQuery, WithCustomChunkSize, Wi
     }
 
     /**
-     * @param resource $resource
+     * @param \Laravel\Nova\Resource $resource
      *
      * @return Collection
      */
@@ -293,7 +293,7 @@ class ExportToExcel extends Action implements FromQuery, WithCustomChunkSize, Wi
     /**
      * @param Model $model
      *
-     * @return resource
+     * @return \Laravel\Nova\Resource
      */
     protected function resolveResource(Model $model): Resource
     {

--- a/src/Concerns/Only.php
+++ b/src/Concerns/Only.php
@@ -2,6 +2,7 @@
 
 namespace Maatwebsite\LaravelNovaExcel\Concerns;
 
+use Laravel\Nova\Http\Requests\ActionRequest;
 use Maatwebsite\LaravelNovaExcel\Requests\ExportActionRequest;
 
 trait Only
@@ -57,14 +58,14 @@ trait Only
     }
 
     /**
-     * @param ExportActionRequest $request
+     * @param ExportActionRequest|ActionRequest $request
      */
     protected function handleOnly(ExportActionRequest $request)
     {
         // If not a specific only array, and user wants only index fields,
         // fill the only with the index fields.
         if ($this->onlyIndexFields && (!is_array($this->only) || count($this->only) === 0)) {
-            $this->only = $request->indexFields();
+            $this->only = $request->indexFields($request->newResource());
         }
     }
 }

--- a/src/Concerns/WithHeadings.php
+++ b/src/Concerns/WithHeadings.php
@@ -79,6 +79,8 @@ trait WithHeadings
                 array_keys($this->map($model))
             );
 
+            // Attempt to replace the attribute name by the resource field name.
+            // Fallback to the attribute name, when none is found.
             return $attributes->map(function (string $attribute) use ($request) {
                 return $request->findHeading($attribute, $attribute);
             })->toArray();

--- a/src/Requests/ExportActionRequest.php
+++ b/src/Requests/ExportActionRequest.php
@@ -2,6 +2,10 @@
 
 namespace Maatwebsite\LaravelNovaExcel\Requests;
 
+use Illuminate\Support\Collection;
+use Laravel\Nova\Fields\Field;
+use Laravel\Nova\Resource;
+
 interface ExportActionRequest
 {
     /**
@@ -10,9 +14,18 @@ interface ExportActionRequest
     public function toExportQuery();
 
     /**
+     * @param Resource $resource
+     *
      * @return array
      */
-    public function indexFields(): array;
+    public function indexFields(Resource $resource): array;
+
+    /**
+     * @param Resource $resource
+     *
+     * @return Collection|Field[]
+     */
+    public function resourceFields(Resource $resource): Collection;
 
     /**
      * @param string      $attribute

--- a/src/Requests/ExportActionRequest.php
+++ b/src/Requests/ExportActionRequest.php
@@ -2,9 +2,9 @@
 
 namespace Maatwebsite\LaravelNovaExcel\Requests;
 
-use Illuminate\Support\Collection;
-use Laravel\Nova\Fields\Field;
 use Laravel\Nova\Resource;
+use Laravel\Nova\Fields\Field;
+use Illuminate\Support\Collection;
 
 interface ExportActionRequest
 {
@@ -14,14 +14,14 @@ interface ExportActionRequest
     public function toExportQuery();
 
     /**
-     * @param Resource $resource
+     * @param resource $resource
      *
      * @return array
      */
     public function indexFields(Resource $resource): array;
 
     /**
-     * @param Resource $resource
+     * @param resource $resource
      *
      * @return Collection|Field[]
      */

--- a/src/Requests/ExportActionRequest.php
+++ b/src/Requests/ExportActionRequest.php
@@ -14,14 +14,14 @@ interface ExportActionRequest
     public function toExportQuery();
 
     /**
-     * @param resource $resource
+     * @param \Laravel\Nova\Resource $resource
      *
      * @return array
      */
     public function indexFields(Resource $resource): array;
 
     /**
-     * @param resource $resource
+     * @param \Laravel\Nova\Resource $resource
      *
      * @return Collection|Field[]
      */

--- a/src/Requests/ExportLensActionRequest.php
+++ b/src/Requests/ExportLensActionRequest.php
@@ -2,10 +2,10 @@
 
 namespace Maatwebsite\LaravelNovaExcel\Requests;
 
+use Laravel\Nova\Resource;
 use Laravel\Nova\Fields\Field;
 use Illuminate\Support\Collection;
 use Laravel\Nova\Http\Requests\LensActionRequest;
-use Laravel\Nova\Resource;
 
 class ExportLensActionRequest extends LensActionRequest implements ExportActionRequest
 {
@@ -13,7 +13,7 @@ class ExportLensActionRequest extends LensActionRequest implements ExportActionR
     use WithHeadingFinder;
 
     /**
-     * @var Resource
+     * @var resource
      */
     protected $resourceInstance;
 
@@ -28,7 +28,7 @@ class ExportLensActionRequest extends LensActionRequest implements ExportActionR
     }
 
     /**
-     * @param Resource $resource
+     * @param resource $resource
      *
      * @return Collection|Field[]
      */

--- a/src/Requests/ExportLensActionRequest.php
+++ b/src/Requests/ExportLensActionRequest.php
@@ -13,7 +13,7 @@ class ExportLensActionRequest extends LensActionRequest implements ExportActionR
     use WithHeadingFinder;
 
     /**
-     * @var resource
+     * @var \Laravel\Nova\Resource
      */
     protected $resourceInstance;
 
@@ -28,7 +28,7 @@ class ExportLensActionRequest extends LensActionRequest implements ExportActionR
     }
 
     /**
-     * @param resource $resource
+     * @param \Laravel\Nova\Resource $resource
      *
      * @return Collection|Field[]
      */

--- a/src/Requests/ExportLensActionRequest.php
+++ b/src/Requests/ExportLensActionRequest.php
@@ -5,11 +5,17 @@ namespace Maatwebsite\LaravelNovaExcel\Requests;
 use Laravel\Nova\Fields\Field;
 use Illuminate\Support\Collection;
 use Laravel\Nova\Http\Requests\LensActionRequest;
+use Laravel\Nova\Resource;
 
 class ExportLensActionRequest extends LensActionRequest implements ExportActionRequest
 {
     use WithIndexFields;
     use WithHeadingFinder;
+
+    /**
+     * @var Resource
+     */
+    protected $resourceInstance;
 
     /**
      * @return \Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder|mixed
@@ -22,10 +28,31 @@ class ExportLensActionRequest extends LensActionRequest implements ExportActionR
     }
 
     /**
+     * @param Resource $resource
+     *
      * @return Collection|Field[]
      */
-    public function resourceFields()
+    public function resourceFields(Resource $resource): Collection
     {
-        return new Collection($this->lens()->fields($this));
+        $this->resourceInstance = $resource;
+
+        $lens           = $this->lens();
+        $lens->resource = $resource->model();
+
+        return $lens->resolveFields($this);
+    }
+
+    /**
+     * Get all of the possible lenses for the request.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function availableLenses()
+    {
+        if (!$this->resourceInstance) {
+            $this->resourceInstance = $this->newResource();
+        }
+
+        return $this->resourceInstance->availableLenses($this);
     }
 }

--- a/src/Requests/ExportResourceActionRequest.php
+++ b/src/Requests/ExportResourceActionRequest.php
@@ -5,6 +5,7 @@ namespace Maatwebsite\LaravelNovaExcel\Requests;
 use Laravel\Nova\Fields\Field;
 use Illuminate\Support\Collection;
 use Laravel\Nova\Http\Requests\ActionRequest;
+use Laravel\Nova\Resource;
 
 class ExportResourceActionRequest extends ActionRequest implements ExportActionRequest
 {
@@ -22,10 +23,12 @@ class ExportResourceActionRequest extends ActionRequest implements ExportActionR
     }
 
     /**
+     * @param Resource $resource
+     *
      * @return Collection|Field[]
      */
-    public function resourceFields()
+    public function resourceFields(Resource $resource): Collection
     {
-        return $this->newResource()->indexFields($this);
+        return $resource->indexFields($this);
     }
 }

--- a/src/Requests/ExportResourceActionRequest.php
+++ b/src/Requests/ExportResourceActionRequest.php
@@ -2,10 +2,10 @@
 
 namespace Maatwebsite\LaravelNovaExcel\Requests;
 
+use Laravel\Nova\Resource;
 use Laravel\Nova\Fields\Field;
 use Illuminate\Support\Collection;
 use Laravel\Nova\Http\Requests\ActionRequest;
-use Laravel\Nova\Resource;
 
 class ExportResourceActionRequest extends ActionRequest implements ExportActionRequest
 {

--- a/src/Requests/ExportResourceActionRequest.php
+++ b/src/Requests/ExportResourceActionRequest.php
@@ -23,7 +23,7 @@ class ExportResourceActionRequest extends ActionRequest implements ExportActionR
     }
 
     /**
-     * @param Resource $resource
+     * @param \Laravel\Nova\Resource $resource
      *
      * @return Collection|Field[]
      */

--- a/src/Requests/SerializedRequest.php
+++ b/src/Requests/SerializedRequest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Maatwebsite\LaravelNovaExcel\Requests;
+
+use Laravel\Nova\Http\Requests\ActionRequest;
+use Laravel\Nova\Http\Requests\LensActionRequest;
+use Laravel\Nova\Http\Requests\NovaRequest;
+
+class SerializedRequest
+{
+    /**
+     * @var string
+     */
+    private $className;
+
+    /**
+     * @var string
+     */
+    private $resource;
+
+    /**
+     * @var null|string
+     */
+    private $lens;
+
+    /**
+     * @param string      $className
+     * @param string      $resource
+     * @param string|null $lens
+     */
+    public function __construct(string $className, string $resource, string $lens = null)
+    {
+        $this->className = $className;
+        $this->resource  = $resource;
+        $this->lens      = $lens;
+    }
+
+    /**
+     * @param ActionRequest|LensActionRequest $request
+     *
+     * @return SerializedRequest
+     */
+    public static function serialize(ActionRequest $request)
+    {
+        return new static(
+            get_class($request),
+            $request->resource,
+            $request->lens
+        );
+    }
+
+    /**
+     * @return NovaRequest|ExportActionRequest
+     */
+    public function unserialize()
+    {
+        $className = $this->className;
+
+        /** @var ExportActionRequest|NovaRequest $request */
+        $request           = new $className;
+        $request->resource = $this->resource;
+        $request->lens     = $this->lens;
+
+        return $request;
+    }
+}

--- a/src/Requests/SerializedRequest.php
+++ b/src/Requests/SerializedRequest.php
@@ -2,9 +2,9 @@
 
 namespace Maatwebsite\LaravelNovaExcel\Requests;
 
+use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Http\Requests\ActionRequest;
 use Laravel\Nova\Http\Requests\LensActionRequest;
-use Laravel\Nova\Http\Requests\NovaRequest;
 
 class SerializedRequest
 {

--- a/src/Requests/WithHeadingFinder.php
+++ b/src/Requests/WithHeadingFinder.php
@@ -12,7 +12,18 @@ trait WithHeadingFinder
      */
     public function findHeading(string $attribute, string $default = null): string
     {
-        return $default;
+        // In case attribute is used multiple times, grab last Field.
+        $field = $this
+            ->newResource()
+            ->indexFields($this)
+            ->where('attribute', $attribute)
+            ->last();
+
+        if (null === $field) {
+            return $default;
+        }
+
+        return $field->name;
     }
 
     /**

--- a/src/Requests/WithIndexFields.php
+++ b/src/Requests/WithIndexFields.php
@@ -2,21 +2,20 @@
 
 namespace Maatwebsite\LaravelNovaExcel\Requests;
 
+use Laravel\Nova\Resource;
 use Laravel\Nova\Fields\Field;
 use Illuminate\Support\Collection;
-use Laravel\Nova\Http\Requests\NovaRequest;
-use Laravel\Nova\Resource;
 
 trait WithIndexFields
 {
     /**
-     * @param Resource $resource
+     * @param resource $resource
      *
      * @return array
      */
     public function indexFields(Resource $resource): array
     {
-        return $this->resourceFields($resource)->map(function(Field $field) {
+        return $this->resourceFields($resource)->map(function (Field $field) {
             if (!$field->computed()) {
                 return $field->attribute;
             }
@@ -26,7 +25,7 @@ trait WithIndexFields
     }
 
     /**
-     * @param Resource $resource
+     * @param resource $resource
      *
      * @return Collection|Field[]
      */

--- a/src/Requests/WithIndexFields.php
+++ b/src/Requests/WithIndexFields.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Collection;
 trait WithIndexFields
 {
     /**
-     * @param resource $resource
+     * @param \Laravel\Nova\Resource $resource
      *
      * @return array
      */
@@ -25,7 +25,7 @@ trait WithIndexFields
     }
 
     /**
-     * @param resource $resource
+     * @param \Laravel\Nova\Resource $resource
      *
      * @return Collection|Field[]
      */

--- a/src/Requests/WithIndexFields.php
+++ b/src/Requests/WithIndexFields.php
@@ -4,19 +4,31 @@ namespace Maatwebsite\LaravelNovaExcel\Requests;
 
 use Laravel\Nova\Fields\Field;
 use Illuminate\Support\Collection;
+use Laravel\Nova\Http\Requests\NovaRequest;
+use Laravel\Nova\Resource;
 
 trait WithIndexFields
 {
     /**
+     * @param Resource $resource
+     *
      * @return array
      */
-    public function indexFields(): array
+    public function indexFields(Resource $resource): array
     {
-        return $this->resourceFields()->map->attribute->all();
+        return $this->resourceFields($resource)->map(function(Field $field) {
+            if (!$field->computed()) {
+                return $field->attribute;
+            }
+
+            return $field->name;
+        })->unique()->all();
     }
 
     /**
+     * @param Resource $resource
+     *
      * @return Collection|Field[]
      */
-    abstract public function resourceFields();
+    abstract public function resourceFields(Resource $resource): Collection;
 }


### PR DESCRIPTION
Adds support for having computed fields in exports.

This opens opportunities for:
- resolve/display callbacks
- Field name instead of attribute as table heading
- BelongsTo
- And of course computed fields.
- Works for both download as queued exports.
- And for both resources and lenses