### PR TITLE
Fix issue 35

### DIFF
--- a/src/Actions/ExportToExcel.php
+++ b/src/Actions/ExportToExcel.php
@@ -306,7 +306,7 @@ class ExportToExcel extends Action implements FromQuery, WithCustomChunkSize, Wi
             if ($model->{$attribute}) {
                 $row[$attribute] = $model->{$attribute};
             } else {
-                $row[$attribute] = ''; 
+                $row[$attribute] = '';
             }
         }
 

--- a/src/Actions/ExportToExcel.php
+++ b/src/Actions/ExportToExcel.php
@@ -305,6 +305,8 @@ class ExportToExcel extends Action implements FromQuery, WithCustomChunkSize, Wi
         foreach (array_diff($only, array_keys($row)) as $attribute) {
             if ($model->{$attribute}) {
                 $row[$attribute] = $model->{$attribute};
+            } else {
+                $row[$attribute] = ''; 
             }
         }
 


### PR DESCRIPTION
As discussed in https://github.com/Maatwebsite/Laravel-Nova-Excel/issues/35 - this is a proposed solution for the issue of exporting empty columns.

Essentially the problem is if a column entry does not exist, we still need to export a "blank" value, otherwise the arrays are not correctly aligned.

Note - I've only tested this for my scenario - and it works.