### PR TITLE
Make QueuedExport action name translatable

### DIFF
--- a/src/Actions/QueuedExport.php
+++ b/src/Actions/QueuedExport.php
@@ -11,7 +11,10 @@ class QueuedExport extends ExportToExcel implements ShouldQueue
     /**
      * @var string
      */
-    public $name = 'Export to Excel';
+    public function name()
+    {
+        return __('Export to Excel');
+    }
 
     /**
      * Remove some attributes from this class when serializing,


### PR DESCRIPTION
I noticed that the action name for queued exports wasn't translatable.