### PR TITLE
I can use an other name to display action

### DIFF
--- a/src/Actions/DownloadExcel.php
+++ b/src/Actions/DownloadExcel.php
@@ -17,7 +17,7 @@ class DownloadExcel extends ExportToExcel
      */
     public function name()
     {
-        return __('Download Excel');
+        return $this->name ?? __('Download Excel');
     }
 
     /**

--- a/src/Actions/QueuedExport.php
+++ b/src/Actions/QueuedExport.php
@@ -46,6 +46,6 @@ class QueuedExport extends ExportToExcel implements ShouldQueue
      */
     public function name()
     {
-        return __('Export to Excel');
+        return $this->name ?? __('Export to Excel');
     }
 }


### PR DESCRIPTION
Add the possibility of using withname method to modify the name of the used actions

```
public function actions(Request $request)
    {
        return [
            (new DownloadExcel())->withName('Download users with heading')->withHeadings(),
            (new DownloadExcel())->withName('Download users'),
            (new DownloadExcel())->withName('Download users with only ...')->only(...),
        ];
    }
```