### PR TITLE
#61 Add extension to filename when using withFilename()

### DIFF
--- a/src/Concerns/WithFilename.php
+++ b/src/Concerns/WithFilename.php
@@ -63,7 +63,7 @@ trait WithFilename
     {
         $fields = $request->resolveFields();
 
-        if ($filename = $fields->get('filename')) {
+        if ($filename = $fields->get('filename', $this->filename)) {
             if (!Str::contains($filename, '.')) {
                 $filename .= '.' . $this->getDefaultExtension();
             }


### PR DESCRIPTION
Update `handleFilename()` to append appropriate file extension when `withFilename()` is used. The extension will continue be appended when `askForFilename()` is used.

This addresses https://github.com/Maatwebsite/Laravel-Nova-Excel/issues/61