### PR TITLE
Using allFields() method breaks export of relationship and computed fields 

### DIFF
--- a/src/Actions/ExportToExcel.php
+++ b/src/Actions/ExportToExcel.php
@@ -193,7 +193,7 @@ class ExportToExcel extends Action implements FromQuery, WithCustomChunkSize, Wi
             $row->setHidden([]);
             $row = $this->replaceFieldValuesWhenOnResource(
                 $row,
-                is_array($only) ? $only : array_keys($row->attributesToArray())
+                $only
             );
         }
 

--- a/src/Concerns/Only.php
+++ b/src/Concerns/Only.php
@@ -8,9 +8,9 @@ use Maatwebsite\LaravelNovaExcel\Requests\ExportActionRequest;
 trait Only
 {
     /**
-     * @var array|null
+     * @var array
      */
-    protected $only;
+    protected $only = [];
 
     /**
      * @var bool
@@ -50,7 +50,7 @@ trait Only
     }
 
     /**
-     * @return array|null
+     * @return array
      */
     public function getOnly()
     {
@@ -64,8 +64,14 @@ trait Only
     {
         // If not a specific only array, and user wants only index fields,
         // fill the only with the index fields.
-        if ($this->onlyIndexFields && (!is_array($this->only) || count($this->only) === 0)) {
-            $this->only = $request->indexFields($request->newResource());
+        $indexFields = $request->indexFields($request->newResource());
+
+        if ($this->onlyIndexFields && count($this->only) === 0) {
+            $this->only = $indexFields;
+        } elseif (!$this->onlyIndexFields) {
+            $modelAttributes = optional($request->toQuery()->first())->attributesToArray() ?: [];
+
+            $this->only = array_merge(array_keys($modelAttributes), $indexFields);
         }
     }
 }


### PR DESCRIPTION
[#48 ]
this PR  merge non index fields with index fields when using allFields method

I have case that i want to export all index fields with non index fields. so i found allFields method but this method breaks export of relationship and computed fields .
so  i found getOnly method in Only Trait  which set only in case of index Fields and count of only  equal zero 
but also needed  to merge non index fields with index fields in case of using allFields method  
