### PR TITLE
Added macro helpers for export availability

### DIFF
--- a/src/LaravelNovaExcelServiceProvider.php
+++ b/src/LaravelNovaExcelServiceProvider.php
@@ -2,8 +2,11 @@
 
 namespace Maatwebsite\LaravelNovaExcel;
 
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
+use Laravel\Nova\Fields\Field;
+use Maatwebsite\LaravelNovaExcel\Requests\ExportResourceActionRequest;
 
 class LaravelNovaExcelServiceProvider extends ServiceProvider
 {
@@ -16,6 +19,40 @@ class LaravelNovaExcelServiceProvider extends ServiceProvider
     {
         $this->app->booted(function () {
             $this->routes();
+        });
+        
+        $this->addExportHelperMacrosToNovaFields();
+    }
+    
+    protected function addExportHelperMacrosToNovaFields()
+    {
+        Field::macro('onlyOnExport', function () {
+            // LaravelNovaExcel only uses fields that are visible in the index
+            return $this
+                // First hide it everywhere except on indexes
+                ->onlyOnIndex()
+                // Then decide when to show it when loaded an index
+                ->showOnIndex(function (Request $request) {
+                    return $request instanceof ExportResourceActionRequest;
+                });
+        });
+
+        Field::macro('showOnExport', function () {
+            // LaravelNovaExcel only uses fields that are visible in the index
+            return $this
+                // In this case we don't care what other places the field is show
+                ->showOnIndex(function (Request $request) {
+                    return $request instanceof ExportResourceActionRequest;
+                });
+        });
+
+        Field::macro('hideOnExport', function () {
+            // LaravelNovaExcel only uses fields that are visible in the index
+            return $this
+                // This way we decide to hide it on exports
+                ->showOnIndex(function (Request $request) {
+                    return !$request instanceof ExportResourceActionRequest;
+                });
         });
     }
 


### PR DESCRIPTION
### Intro
I've added some useful macros to the Nova Field which helps to determine a whether a field is available on the export or not. 

There are 3 macros:
- hideOnExport - The field can be available on index requests but will not be shown on export requests
- onlyOnExport - The field is only available on export requests
- showOnExport - The field is available on export requests and maybe create/update requests, depending on the defined logic.

### Reason
The reason for this is on the index and/or detail requests you'll want to format fields like email addresses and phone numbers as HTML using a `displayUsing` callback. But this results in errors saying that the `displayUsing` callback is receiving a null value where it expects a string. You could change the type hinting to `?string` or  remove the type hinting, but that is not a good solution in my opinion.

### Example (which throws errors):
```
Text::make(__('Email'), 'email')
  ->rules('required', 'email')
  ->displayUsing(fn(string $email): string => "<a target='_blank' href='mailto:{$email}'>{$email}</a>")
  ->asHtml(),
```

Solution (after this being merged):
```
Text::make(__('Email'), 'email')
  ->rules('required', 'email')
  ->displayUsing(fn(string $email): string => "<a target='_blank' href='mailto:{$email}'>{$email}</a>")
  ->asHtml()
  ->hideOnExport(),

Text::make(__('Email'), 'email')
  ->onlyOnExport(),
```

### Outro
I'm wondering what others think of this solution and maybe this can get merged so others can enjoy these helpful macros.



