### PR TITLE
Support downloads in multi server setup or serverless

### DIFF
--- a/src/Actions/DownloadExcel.php
+++ b/src/Actions/DownloadExcel.php
@@ -1,4 +1,4 @@
-<?php
+    <?php
 
 namespace Maatwebsite\LaravelNovaExcel\Actions;
 
@@ -8,7 +8,6 @@ use Laravel\Nova\Actions\Action;
 use Laravel\Nova\Http\Requests\ActionRequest;
 use Maatwebsite\Excel\Facades\Excel;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
-
 
 class DownloadExcel extends ExportToExcel
 {
@@ -63,7 +62,7 @@ class DownloadExcel extends ExportToExcel
     public function handleRemoteDisk(ActionRequest $request, Action $exportable): array
     {
         $temporaryFilePath = config('excel.temporary_files.remote_prefix') . 'laravel-excel-' . Str::random(32) . '.' . $this->getDefaultExtension();
-        $isStored = Excel::store($exportable, $temporaryFilePath, config('excel.temporary_files.remote_disk'), $this->getWriterType());
+        $isStored          = Excel::store($exportable, $temporaryFilePath, config('excel.temporary_files.remote_disk'), $this->getWriterType());
 
         if (!$isStored) {
             return \is_callable($this->onFailure)

--- a/src/Actions/DownloadExcel.php
+++ b/src/Actions/DownloadExcel.php
@@ -1,4 +1,4 @@
-    <?php
+<?php
 
 namespace Maatwebsite\LaravelNovaExcel\Actions;
 

--- a/src/Http/Controllers/ExcelController.php
+++ b/src/Http/Controllers/ExcelController.php
@@ -6,6 +6,7 @@ use Illuminate\Foundation\Validation\ValidatesRequests;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Routing\ResponseFactory;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Validation\ValidationException;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -31,10 +32,10 @@ class ExcelController extends Controller
 
         if (config('excel.temporary_files.remote_disk')) {
             app()->terminating(function () use ($decryptedPath) {
-                \Storage::disk(config('excel.temporary_files.remote_disk'))->delete($decryptedPath);
+                Storage::disk(config('excel.temporary_files.remote_disk'))->delete($decryptedPath);
             });
 
-            return \Storage::disk(config('excel.temporary_files.remote_disk'))
+            return Storage::disk(config('excel.temporary_files.remote_disk'))
                 ->download($decryptedPath, $data['filename']);
         } else {
             return $response->download(

--- a/src/Http/Controllers/ExcelController.php
+++ b/src/Http/Controllers/ExcelController.php
@@ -7,7 +7,7 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Routing\ResponseFactory;
 use Illuminate\Validation\ValidationException;
-use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\Response;
 
 class ExcelController extends Controller
 {
@@ -17,19 +17,30 @@ class ExcelController extends Controller
      * @param Request         $request
      * @param ResponseFactory $response
      *
-     * @return BinaryFileResponse
+     * @return Response
      * @throws ValidationException
      */
-    public function download(Request $request, ResponseFactory $response): BinaryFileResponse
+    public function download(Request $request, ResponseFactory $response): Response
     {
         $data = $this->validate($request, [
             'path'     => 'required',
             'filename' => 'required',
         ]);
 
-        return $response->download(
-            decrypt($data['path']),
-            $data['filename']
-        )->deleteFileAfterSend($shouldDelete = true);
+        $decryptedPath = decrypt($data['path']);
+
+        if (config('excel.temporary_files.remote_disk')) {
+            app()->terminating(function () use ($decryptedPath) {
+                \Storage::disk(config('excel.temporary_files.remote_disk'))->delete($decryptedPath);
+            });
+
+            return \Storage::disk(config('excel.temporary_files.remote_disk'))
+                ->download($decryptedPath, $data['filename']);
+        } else {
+            return $response->download(
+                decrypt($data['path']),
+                $data['filename']
+            )->deleteFileAfterSend($shouldDelete = true);
+        }
     }
 }


### PR DESCRIPTION
Fixes #119 

This implementation re-uses the Laravel Excel config.
I've chosen this approach as the situations where a user would use `excel.temporary_files.remote_disk` (multiple application servers or serverless) also require the Download action to store the file remotely. 

Currently it is only tested on a multi server setup as I do not have experience working with Laravel Vapor.