### PR TITLE
Allow for "Select All on Current Page" to work with Lenses that use aggregates

### DIFF
--- a/src/Actions/ExportToExcel.php
+++ b/src/Actions/ExportToExcel.php
@@ -52,6 +52,11 @@ class ExportToExcel extends Action implements FromQuery, WithCustomChunkSize, Wi
     protected $resource;
 
     /**
+     * @var string
+     */
+    protected $exportQueryKey;
+
+    /**
      * @var Builder
      */
     protected $query;
@@ -85,7 +90,7 @@ class ExportToExcel extends Action implements FromQuery, WithCustomChunkSize, Wi
         $this->resource = $request->resource();
         $this->request  = ExportActionRequestFactory::make($request);
 
-        $query = $this->request->toExportQuery();
+        $query = $this->request->toExportQuery($this->exportQueryKey);
         $this->handleOnly($this->request);
         $this->handleHeadings($query, $this->request);
 
@@ -146,6 +151,17 @@ class ExportToExcel extends Action implements FromQuery, WithCustomChunkSize, Wi
     public function withName(string $name)
     {
         $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * @param string $exportQueryKey
+     * @return $this
+     */
+    public function withExportQueryKey(string $exportQueryKey)
+    {
+        $this->exportQueryKey = $exportQueryKey;
 
         return $this;
     }

--- a/src/Requests/ExportLensActionRequest.php
+++ b/src/Requests/ExportLensActionRequest.php
@@ -18,12 +18,15 @@ class ExportLensActionRequest extends LensActionRequest implements ExportActionR
     protected $resourceInstance;
 
     /**
+     * @param string|null $exportQueryKey
      * @return \Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder|mixed
      */
-    public function toExportQuery()
+    public function toExportQuery(string $exportQueryKey = null)
     {
-        return $this->toQuery()->when(!$this->forAllMatchingResources(), function ($query) {
-            $query->whereKey(explode(',', $this->resources));
+        return $this->toQuery()->when(!$this->forAllMatchingResources(), function ($query) use ($exportQueryKey) {
+            $exportQueryKey
+            ? $query->whereIn($exportQueryKey, explode(',', $this->resources))
+            : $query->whereKey(explode(',', $this->resources));
         });
     }
 


### PR DESCRIPTION
As per issue #90 - when using an export query that is not `forAllMatchingResources`, the default behaviour was to use the Laravel `withKey` which selects the primary key (usually `id`) of the _Resource_ in question, disregarded the key of the _Lens_ for that resource (which may be an aggregate lens using `COUNT()` and `GROUP BY` SQL)

The solution as best as I can see, is to allow overriding this behaviour using a `withExportQueryKey()` option that lets the user specify a different key for a Lens Action. If there is a cleaner or more 'Laravel' way to do it, that would be great, but this does fix the issue and let me use paginated downloadable Excel Actions from aggregate Lenses.

