### PR TITLE
Use Group clause in ExportLensActionRequest to allow for aggregate Lens exports

### DIFF
--- a/src/Requests/ExportLensActionRequest.php
+++ b/src/Requests/ExportLensActionRequest.php
@@ -23,7 +23,11 @@ class ExportLensActionRequest extends LensActionRequest implements ExportActionR
     public function toExportQuery()
     {
         return $this->toQuery()->when(!$this->forAllMatchingResources(), function ($query) {
-            $query->whereKey(explode(',', $this->resources));
+            $groups = $query->getQuery()->groups;
+
+            is_array($groups) && count($groups)
+            ? $query->whereIn($groups[0], explode(',', $this->resources))
+            : $query->whereKey(explode(',', $this->resources));
         });
     }
 

--- a/src/Requests/ExportLensActionRequest.php
+++ b/src/Requests/ExportLensActionRequest.php
@@ -25,9 +25,9 @@ class ExportLensActionRequest extends LensActionRequest implements ExportActionR
         return $this->toQuery()->when(!$this->forAllMatchingResources(), function ($query) {
             $groups = $query->getQuery()->groups;
 
-            is_array($groups) && count($groups) === 1
-            ? $query->whereIn($groups[0], explode(',', $this->resources))
-            : $query->whereKey(explode(',', $this->resources));
+            is_array($groups) && 1 === count($groups)
+                ? $query->whereIn($groups[0], explode(',', $this->resources))
+                : $query->whereKey(explode(',', $this->resources));
         });
     }
 

--- a/src/Requests/ExportLensActionRequest.php
+++ b/src/Requests/ExportLensActionRequest.php
@@ -25,7 +25,7 @@ class ExportLensActionRequest extends LensActionRequest implements ExportActionR
         return $this->toQuery()->when(!$this->forAllMatchingResources(), function ($query) {
             $groups = $query->getQuery()->groups;
 
-            is_array($groups) && count($groups)
+            is_array($groups) && count($groups) === 1
             ? $query->whereIn($groups[0], explode(',', $this->resources))
             : $query->whereKey(explode(',', $this->resources));
         });


### PR DESCRIPTION
As per issue #90 - when using an export query that is not `forAllMatchingResources`, the default behaviour was to use the Laravel `withKey` which selects the primary key (usually `id`) of the _Resource_ in question, disregarded the key of the _Lens_ for that resource (which may be an aggregate lens using `COUNT()` and `GROUP BY` SQL)

The solution is to check for a `groups` clause in the Lenses underlying query builder, and if it exists, to use that with a `whereIn()` instead

