### PR TITLE
Update `laravie/serialize-queries` for Laravel 9 supports

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   "require": {
     "php": ">=7.1.0",
     "laravel/nova": "*",
-    "laravie/serialize-queries": "^0.3|^1.0",
+    "laravie/serialize-queries": "^1.0|^2.0",
     "maatwebsite/excel": "^3.1"
   },
   "autoload": {


### PR DESCRIPTION
* Support v2: https://github.com/laravie/serialize-queries/releases/tag/v2.0.0
* Remove `^0.3` as it no longer receiving any bugfixes and is identical to `^1.0`
