### PR TITLE
Vapor fix - Delete temp file via queued closure instead of app terminating

### DIFF
--- a/src/Actions/DownloadExcel.php
+++ b/src/Actions/DownloadExcel.php
@@ -2,7 +2,6 @@
 
 namespace Maatwebsite\LaravelNovaExcel\Actions;
 
-use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Str;
 use Laravel\Nova\Actions\Action;
@@ -83,13 +82,6 @@ class DownloadExcel extends ExportToExcel
      */
     protected function getDownloadUrl(string $filePath): string
     {
-        if ($remoteDisk = config('excel.temporary_files.remote_disk')) {
-            return Storage::disk($remoteDisk)
-                ->temporaryUrl($filePath, now()->addMinutes(1), [
-                    'ResponseContentDisposition' => 'filename="' . $this->getFilename() . '"',
-                ]);
-        }
-
         return URL::temporarySignedRoute('laravel-nova-excel.download', now()->addMinutes(1), [
             'path'     => encrypt($filePath),
             'filename' => $this->getFilename(),

--- a/src/Actions/DownloadExcel.php
+++ b/src/Actions/DownloadExcel.php
@@ -2,6 +2,7 @@
 
 namespace Maatwebsite\LaravelNovaExcel\Actions;
 
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Str;
 use Laravel\Nova\Actions\Action;
@@ -82,6 +83,13 @@ class DownloadExcel extends ExportToExcel
      */
     protected function getDownloadUrl(string $filePath): string
     {
+        if ($remoteDisk = config('excel.temporary_files.remote_disk')) {
+            return Storage::disk($remoteDisk)
+                ->temporaryUrl($filePath, now()->addMinutes(1), [
+                    'ResponseContentDisposition' => 'filename="' . $this->getFilename() . '"',
+                ]);
+        }
+
         return URL::temporarySignedRoute('laravel-nova-excel.download', now()->addMinutes(1), [
             'path'     => encrypt($filePath),
             'filename' => $this->getFilename(),

--- a/src/Http/Controllers/ExcelController.php
+++ b/src/Http/Controllers/ExcelController.php
@@ -31,9 +31,11 @@ class ExcelController extends Controller
         $decryptedPath = decrypt($data['path']);
 
         if (config('excel.temporary_files.remote_disk')) {
-            dispatch(function () use ($decryptedPath): void {
-                Storage::disk(config('excel.temporary_files.remote_disk'))->delete($decryptedPath);
-            })->delay(now()->addMinute());
+            app()->terminating(function () use ($decryptedPath) {
+                dispatch(function () use ($decryptedPath): void {
+                    Storage::disk(config('excel.temporary_files.remote_disk'))->delete($decryptedPath);
+                })->delay(now()->addMinute());
+            });
 
             return Storage::disk(config('excel.temporary_files.remote_disk'))
                 ->download($decryptedPath, $data['filename']);

--- a/src/Http/Controllers/ExcelController.php
+++ b/src/Http/Controllers/ExcelController.php
@@ -31,9 +31,9 @@ class ExcelController extends Controller
         $decryptedPath = decrypt($data['path']);
 
         if (config('excel.temporary_files.remote_disk')) {
-            app()->terminating(function () use ($decryptedPath) {
+            dispatch(function () use ($decryptedPath): void {
                 Storage::disk(config('excel.temporary_files.remote_disk'))->delete($decryptedPath);
-            });
+            })->delay(now()->addMinute());
 
             return Storage::disk(config('excel.temporary_files.remote_disk'))
                 ->download($decryptedPath, $data['filename']);


### PR DESCRIPTION
Exports in Laravel Nova on Vapor are giving a `Illuminate\Contracts\Filesystem\FileNotFoundException` while working locally.

Exception message:
> File not found at path: temp/laravel-excel-e0Eeo8ZF7f6SYKKmzbqDI5GTKLBAlLtt.xlsx 

This PR lets the disk handle the creation of the temporary URL to download the file when a remote disk is configured. 
Without this change, it seems that it will try and download the local file instead of the remote file.