### PR TITLE
Update WithHeadingFinder.php to fix heading fields for lens exports

### DIFF
--- a/src/Requests/WithHeadingFinder.php
+++ b/src/Requests/WithHeadingFinder.php
@@ -12,9 +12,7 @@ trait WithHeadingFinder
     public function findHeading(string $attribute, string $default = null)
     {
         // In case attribute is used multiple times, grab last Field.
-        $field = $this
-            ->newResource()
-            ->indexFields($this)
+        $field = collect($this->resourceFields($this->newResource()))
             ->where('attribute', $attribute)
             ->last();
 


### PR DESCRIPTION
NOTE - This pull request is for the 1.2 branch because I am stuck on Nova 3 in the project I'm working on. The fix should be identical for 1.3 and 2.0 though.

When exporting from a lens, the WithHeaderFinder still uses a normal resource's index fields, instead of the lens fields. Therefore if you have any fields in the lens that are not in the index fields for the normal resource, the heading finder cannot locate them and falls back to the attribute name (eg field_name instead of Field Name)

This pull request simply uses the resourceFields (which are used for the export) to lookup the headings. This doesn't adversely affect a normal resource export because ExportResourceActionRequest uses indexFields in its resourceFields method, and it fixes ExportLensActionRequest to correctly locate the header names.