### PR TITLE
Update WithHeadingFinder.php to fix heading fields for lens exports

### DIFF
--- a/src/Requests/WithHeadingFinder.php
+++ b/src/Requests/WithHeadingFinder.php
@@ -12,9 +12,7 @@ trait WithHeadingFinder
     public function findHeading(string $attribute, string $default = null)
     {
         // In case attribute is used multiple times, grab last Field.
-        $field = $this
-            ->newResource()
-            ->indexFields($this)
+        $field = collect($this->resourceFields($this->newResource()))
             ->where('attribute', $attribute)
             ->last();
 


### PR DESCRIPTION
See https://github.com/SpartnerNL/Laravel-Nova-Excel/pull/155 for details, this is the same fix for the 1.3 branch

It fixes issues with determining heading titles when the actual fields don't exist in the resource itself