### PR TITLE
Update ExportToExcel for error due to Action class mismatch

### DIFF
--- a/src/Actions/ExportToExcel.php
+++ b/src/Actions/ExportToExcel.php
@@ -141,17 +141,6 @@ class ExportToExcel extends Action implements FromQuery, WithCustomChunkSize, Wi
     }
 
     /**
-     * @param  string  $name
-     * @return $this
-     */
-    public function withName(string $name)
-    {
-        $this->name = $name;
-
-        return $this;
-    }
-
-    /**
      * @return Builder
      */
     public function query()


### PR DESCRIPTION
Fixes an error using this package with Nova 4. The function can be removed, as it is identical to the base Action class function.