### PR TITLE
Remove inherited withName method

### DIFF
--- a/src/Actions/ExportToExcel.php
+++ b/src/Actions/ExportToExcel.php
@@ -139,7 +139,7 @@ class ExportToExcel extends Action implements FromQuery, WithCustomChunkSize, Wi
 
         return $this;
     }
-    
+
     /**
      * @return Builder
      */

--- a/src/Actions/ExportToExcel.php
+++ b/src/Actions/ExportToExcel.php
@@ -139,18 +139,7 @@ class ExportToExcel extends Action implements FromQuery, WithCustomChunkSize, Wi
 
         return $this;
     }
-
-    /**
-     * @param  string  $name
-     * @return $this
-     */
-    public function withName(string $name)
-    {
-        $this->name = $name;
-
-        return $this;
-    }
-
+    
     /**
      * @return Builder
      */


### PR DESCRIPTION
This is a fix for #161. It simply removes the inherited method as it is identical to the parent method, apart from the thing that causes the crash in #161.