### PR TITLE
Incorrect handle() return type on actions

### DIFF
--- a/src/Actions/DownloadExcel.php
+++ b/src/Actions/DownloadExcel.php
@@ -24,9 +24,9 @@ class DownloadExcel extends ExportToExcel
     /**
      * @param  ActionRequest  $request
      * @param  Action  $exportable
-     * @return array
+     * @return mixed
      */
-    public function handle(ActionRequest $request, Action $exportable): array
+    public function handle(ActionRequest $request, Action $exportable)
     {
         if (config('excel.temporary_files.remote_disk')) {
             return $this->handleRemoteDisk($request, $exportable);

--- a/src/Actions/ExportToExcel.php
+++ b/src/Actions/ExportToExcel.php
@@ -96,9 +96,9 @@ class ExportToExcel extends Action implements FromQuery, WithCustomChunkSize, Wi
     /**
      * @param  ActionRequest  $request
      * @param  Action  $exportable
-     * @return array
+     * @return mixed
      */
-    public function handle(ActionRequest $request, Action $exportable): array
+    public function handle(ActionRequest $request, Action $exportable)
     {
         $response = Excel::store(
             $exportable,


### PR DESCRIPTION
The handle method can actually return anything, due to the nature of the option `onSuccess` and `onFailure` options. However, by default an `ActionResponse` is returned, rather than an array.