### PR TITLE
Update Fields setting pre defined parameter as null to fix compatibility with Nova 4

### DIFF
--- a/src/Actions/ExportToExcel.php
+++ b/src/Actions/ExportToExcel.php
@@ -149,10 +149,10 @@ class ExportToExcel extends Action implements FromQuery, WithCustomChunkSize, Wi
     }
 
     /**
-     * @param  NovaRequest  $request
+     * @param NovaRequest|null $request
      * @return Field[]
      */
-    public function fields(NovaRequest $request)
+    public function fields(NovaRequest $request = null)
     {
         return $this->actionFields;
     }


### PR DESCRIPTION
Hello,

I'm with some problems with laravel nova excel package after update my laravel to version 10. 

This version use Nova 4 and  seems not be supported with laravel nova excel. 
To fixe it we made a change in vendor folder, in file ExportToExcel, in method "fields", setting NovaRequest $request parameter as pre defined as null.

But make changes in vendor folder it's not a nice thing to do, so i made a custom solution here!