### PR TITLE
Resources attribute can be array

### DIFF
--- a/src/Requests/ExportResourceActionRequest.php
+++ b/src/Requests/ExportResourceActionRequest.php
@@ -18,7 +18,9 @@ class ExportResourceActionRequest extends ActionRequest implements ExportActionR
     public function toExportQuery()
     {
         return $this->toSelectedResourceQuery()->when(!$this->forAllMatchingResources(), function ($query) {
-            $query->whereKey(explode(',', $this->resources));
+            $query->whereKey(
+                is_array($this->resources) ? $this->resources : explode(',', $this->resources)
+            );
         });
     }
 


### PR DESCRIPTION
Resources attribute of Laravel\Nova\Http\Requests\ActionRequest can be null, string or array