### PR TITLE
Fix for Nova 4.35.0

### DIFF
--- a/src/Requests/ExportLensActionRequest.php
+++ b/src/Requests/ExportLensActionRequest.php
@@ -26,8 +26,8 @@ class ExportLensActionRequest extends LensActionRequest implements ExportActionR
             $groups = $query->getQuery()->groups;
 
             is_array($groups) && 1 === count($groups)
-                ? $query->whereIn($groups[0], explode(',', $this->resources))
-                : $query->whereKey(explode(',', $this->resources));
+                ? $query->whereIn($groups[0], is_array($this->resources) ? $this->resources : explode(',', $this->resources))
+                : $query->whereKey(is_array($this->resources) ? $this->resources : explode(',', $this->resources));
         });
     }
 

--- a/src/Requests/ExportResourceActionRequest.php
+++ b/src/Requests/ExportResourceActionRequest.php
@@ -18,7 +18,7 @@ class ExportResourceActionRequest extends ActionRequest implements ExportActionR
     public function toExportQuery()
     {
         return $this->toSelectedResourceQuery()->when(!$this->forAllMatchingResources(), function ($query) {
-            $query->whereKey(explode(',', $this->resources));
+            $query->whereKey(is_array($this->resources) ? $this->resources : explode(',', $this->resources));
         });
     }
 


### PR DESCRIPTION
Nova 4.35.0 changes the action $this->resources to be an array instead of a string of commas. This PR fixes the code to work with both pre-4.35.0 and 4.35.0.