### PR TITLE
Fix Nova deprecations

### DIFF
--- a/src/Actions/DownloadExcel.php
+++ b/src/Actions/DownloadExcel.php
@@ -46,9 +46,9 @@ class DownloadExcel extends ExportToExcel
 
         return \is_callable($this->onSuccess)
             ? ($this->onSuccess)($request, $response)
-            : Action::download(
-                $this->getDownloadUrl($response->getFile()->getPathname()),
-                $this->getFilename()
+            : Action::downloadURL(
+                $this->getFilename(),
+                $this->getDownloadUrl($response->getFile()->getPathname())
             );
     }
 
@@ -70,9 +70,9 @@ class DownloadExcel extends ExportToExcel
 
         return \is_callable($this->onSuccess)
             ? ($this->onSuccess)($request, $temporaryFilePath)
-            : Action::download(
-                $this->getDownloadUrl($temporaryFilePath),
-                $this->getFilename()
+            : Action::downloadURL(
+                $this->getFilename(),
+                $this->getDownloadUrl($temporaryFilePath)
             );
     }
 


### PR DESCRIPTION
Sentry keep alert me about the following deprecations.

Method Laravel\Nova\Actions\Action::download() is deprecated since 4.31.2, Use `downloadURL()` method instead

The last version of Nova 4 is 4.35.5

You may want to edit composer.json to make minimum 4.31.2 too

Hence this PR.

The documentation for Action::downloadURL() is here:

https://nova.laravel.com/docs/v5/actions/registering-actions#downloading-files

That said, I'm not confident if my PR is correct