### PR TITLE
Fixed ExportLensActionRequest::availableLenses is incompatible

### DIFF
--- a/src/Requests/ExportLensActionRequest.php
+++ b/src/Requests/ExportLensActionRequest.php
@@ -52,7 +52,7 @@ class ExportLensActionRequest extends LensActionRequest implements ExportActionR
      *
      * @return \Illuminate\Support\Collection
      */
-    public function availableLenses()
+    public function availableLenses(): Collection
     {
         if (!$this->resourceInstance) {
             $this->resourceInstance = $this->newResource();


### PR DESCRIPTION
Fixed `ExportLensActionRequest::availableLenses` is an incompatible override of` LensActionRequest::availableLenses` issue.

Error:
> Declaration of Maatwebsite\LaravelNovaExcel\Requests\ExportLensActionRequest::availableLenses() must be compatible with Laravel\Nova\Http\Requests\LensActionRequest::availableLenses(): Illuminate\Support\Collection

Fixes this issue: 
https://github.com/SpartnerNL/Laravel-Nova-Excel/issues/188
