### PR TITLE
Fix incompatibility with Nova 5.6.2 (8 May 2025)

### DIFF
--- a/src/Actions/ExportToExcel.php
+++ b/src/Actions/ExportToExcel.php
@@ -50,7 +50,7 @@ class ExportToExcel extends Action implements FromQuery, WithCustomChunkSize, Wi
     /**
      * @var string
      */
-    protected $resource;
+    public $resource;
 
     /**
      * @var Builder


### PR DESCRIPTION
When i composer update to Nova 5.6.2 today (Released 8 May 2025)

I got this error

Access level to Maatwebsite\LaravelNovaExcel\Actions\ExportToExcel::$resource must be public (as in class Laravel\Nova\Actions\Action)