### PR TITLE
fix DownloadExcel action

### DIFF
--- a/src/Actions/DownloadExcel.php
+++ b/src/Actions/DownloadExcel.php
@@ -5,6 +5,7 @@ namespace Maatwebsite\LaravelNovaExcel\Actions;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Str;
 use Laravel\Nova\Actions\Action;
+use Laravel\Nova\Actions\ActionResponse;
 use Laravel\Nova\Http\Requests\ActionRequest;
 use Maatwebsite\Excel\Facades\Excel;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
@@ -46,7 +47,7 @@ class DownloadExcel extends ExportToExcel
 
         return \is_callable($this->onSuccess)
             ? ($this->onSuccess)($request, $response)
-            : Action::downloadURL(
+            : ActionResponse::download(
                 $this->getFilename(),
                 $this->getDownloadUrl($response->getFile()->getPathname())
             );
@@ -70,7 +71,7 @@ class DownloadExcel extends ExportToExcel
 
         return \is_callable($this->onSuccess)
             ? ($this->onSuccess)($request, $temporaryFilePath)
-            : Action::downloadURL(
+            : ActionResponse::download(
                 $this->getFilename(),
                 $this->getDownloadUrl($temporaryFilePath)
             );


### PR DESCRIPTION
In latest release 1.3.12, a bug was introduced as `Action::downloadURL` add an action to download an url in the action resource dropdown. In our case, nothing is download to the client.

As we already have an entry in action and want to download our generated file, we need to use `ActionResponse::download`

Thanks!