### PR TITLE
fix: cast Nova 5 field names to string before using as array keys

### DIFF
--- a/src/Actions/ExportToExcel.php
+++ b/src/Actions/ExportToExcel.php
@@ -230,11 +230,13 @@ class ExportToExcel extends Action implements FromQuery, WithCustomChunkSize, Wi
                 continue;
             }
 
+            $name = (string) $field->name;
+
             if (\in_array($field->attribute, $only, true)) {
                 $row[$field->attribute] = $field->value;
-            } elseif (\in_array($field->name, $only, true)) {
+            } elseif (\in_array($name, $only, true)) {
                 // When no field could be found by their attribute name, it's most likely a computed field.
-                $row[$field->name] = $field->value;
+                $row[$name] = $field->value;
             }
         }
 

--- a/src/Requests/WithHeadingFinder.php
+++ b/src/Requests/WithHeadingFinder.php
@@ -20,7 +20,7 @@ trait WithHeadingFinder
             return $default;
         }
 
-        return $field->name;
+        return (string) $field->name;
     }
 
     /**

--- a/src/Requests/WithIndexFields.php
+++ b/src/Requests/WithIndexFields.php
@@ -19,7 +19,7 @@ trait WithIndexFields
                 return $field->attribute;
             }
 
-            return $field->name;
+            return (string) $field->name;
         })->unique()->all();
     }
 


### PR DESCRIPTION
## The bug

Nova 5 changed `Field::$name` from a string to a `Laravel\Nova\Support\PendingTranslation` object. A few places in the export path use that value as an array key, which is fatal:

```
TypeError: Cannot access offset of type Laravel\Nova\Support\PendingTranslation on array
    src/Actions/ExportToExcel.php:244 replaceFieldValuesWhenOnResource
    src/Actions/ExportToExcel.php:179 map
    src/Concerns/WithHeadings.php:78 handleHeadings
    src/Actions/ExportToExcel.php:91 handleRequest
```

This only hits the computed field branches, so a resource whose fields are all column backed exports fine. But add a single computed field and the export dies on the first row:

```php
Text::make('Code', fn () => $this->human_code)
```

We hit this in production on a resource with six of them. composer.json already advertises `laravel/nova: ^4.0|^5.0`, so it looks supported until you have a computed field.

## Where the object gets in

Two places put it into `$only`, and then it gets used as a key:

- `WithIndexFields::indexFields()` returns `$field->name` for computed fields, which seeds `Only::handleOnly()`
- `WithHeadingFinder::findHeading()` does the same for the heading row
- `ExportToExcel::replaceFieldValuesWhenOnResource()` then does `$row[$field->name] = ...`

The `array_merge(array_flip($only), $row)` sort line at the end of that same method is a second failure point too, `array_flip()` rejects object values outright. That might be what #24 (`array_flip(): Can only flip STRING and INTEGER values!`) was, though that one predates Nova 5 so I can't say for sure.

## The fix

Cast to string at each point of use. `PendingTranslation` implements `Stringable`, so this resolves the translation properly, and it's a no-op where the name is already a string, so Nova 4 behaviour doesn't change and there's no need to gate on a version. Kept it PHP 7.1 compatible to match the composer constraint.

Three lines across three files.

## Testing

Verified against a Nova 5.7 / Laravel 12 app with a resource that has six computed fields (`Text`, `Badge`, `Currency` and a `BelongsTo`).

On `2.x` it throws the TypeError above. With this patch the export completes and the contents are correct, all headings resolve to strings and every computed field resolves to its real value rather than being blank or dropped.

I checked 1.3.13, 2.0.1 and the current `2.x` tip and the line is identical in all three, so this isn't something the v2 release fixed.

I haven't added a regression test as there's no test suite in the repo at the moment. Happy to add one if you want to bootstrap it, though it needs a Nova install to be meaningful.
